### PR TITLE
Mejoras en configuración y gestión de órdenes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE=https://fake-api-bsyr.onrender.com

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+.env

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ npm install
 npm run dev
 ```
 
+### Variables de entorno
+
+Cree un archivo `.env` basado en `.env.example` para especificar la base de la API.
+
+```
+VITE_API_BASE=https://mi-api.com
+```
+
 ### Compile and Minify for Production
 
 ```sh

--- a/src/domains/client/orders/components/CreateOrderModal/CreateOrderModal.vue
+++ b/src/domains/client/orders/components/CreateOrderModal/CreateOrderModal.vue
@@ -37,7 +37,8 @@ import ProgressStepper from './ProgressStepper.vue'
 import StepOrderDetails from './StepOrderDetails.vue'
 import StepPayments from './StepPayments.vue'
 import StepConfirmOrder from './StepConfirmOrder.vue'
-import { createOrder } from '@/domains/client/orders/services/orderService.js'
+import { useOrdersStore } from '../../store/useOrdersStore'
+const ordersStore = useOrdersStore()
 
 const emit = defineEmits(['close'])
 
@@ -103,7 +104,7 @@ async function confirmOrder() {
       }
     })
 
-    await createOrder({
+    await ordersStore.addOrder({
       id: Date.now(),
       created: new Date().toISOString().split('T')[0],
       user: formData.value.fullName,
@@ -114,11 +115,9 @@ async function confirmOrder() {
       products: enrichedProducts
     })
 
-    alert('✅ Orden creada exitosamente.')
-    window.location.reload()
+    emit('close')
   } catch (err) {
     console.error('❌ Detalle del error en confirmOrder:', err.message, err.response?.data)
-    alert('❌ Hubo un error al crear la orden.')
   }
 
 }

--- a/src/domains/client/orders/store/useOrdersStore.ts
+++ b/src/domains/client/orders/store/useOrdersStore.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia'
+import { getOrders, createOrder } from '../services/orderService.js'
+
+export const useOrdersStore = defineStore('orders', {
+  state: () => ({
+    orders: [] as any[],
+    isLoading: false
+  }),
+  actions: {
+    async fetchOrders() {
+      this.isLoading = true
+      try {
+        this.orders = await getOrders()
+      } finally {
+        this.isLoading = false
+      }
+    },
+    async addOrder(order: any) {
+      const newOrder = await createOrder(order)
+      this.orders.push(newOrder)
+    }
+  }
+})
+
+export type OrdersStore = ReturnType<typeof useOrdersStore>

--- a/src/domains/client/orders/views/OrdersList.vue
+++ b/src/domains/client/orders/views/OrdersList.vue
@@ -34,10 +34,11 @@ import FiltersPanel from '@/domains/client/orders/components/FiltersPanel.vue'
 import OrdersTable from '@/domains/client/orders/components/OrdersTable.vue'
 import PaginationControls from '@/domains/client/orders/components/PaginationControls.vue'
 import CreateOrderModal from '@/domains/client/orders/components/CreateOrderModal/CreateOrderModal.vue'
-import { getOrders } from '@/domains/client/orders/services/orderService.js'
+import { useOrdersStore } from '../store/useOrdersStore'
 
 // Estado reactivo
-const orders = ref([])
+const ordersStore = useOrdersStore()
+const orders = computed(() => ordersStore.orders)
 const currentPage = ref(1)
 const itemsPerPage = ref(13)
 const showModal = ref(false)
@@ -48,7 +49,7 @@ const endDateFilter = ref('')
 
 // Obtener data al montar
 onMounted(async () => {
-  orders.value = await getOrders()
+  await ordersStore.fetchOrders()
 })
 
 // Aplicar filtros desde panel
@@ -94,7 +95,7 @@ function handleLimitChange(newLimit) {
 
 async function handleModalClose() {
   showModal.value = false
-  orders.value = await getOrders()
+  await ordersStore.fetchOrders()
 }
 </script>
 

--- a/src/domains/supplier/dispatch/views/ReleasedOrders.vue
+++ b/src/domains/supplier/dispatch/views/ReleasedOrders.vue
@@ -59,12 +59,13 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import axios from 'axios'
+import API_BASE from '@/services/api'
 
 const orders = ref([])
 
 async function fetchReleasedOrders() {
   try {
-    const res = await axios.get('http://localhost:3000/orders?status=Released')
+    const res = await axios.get(`${API_BASE}/orders?status=Released`)
     orders.value = res.data
   } catch (error) {
     console.error('❌ Error fetching released orders:', error)

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,3 +1,7 @@
 // src/services/api.js
-const API_BASE = 'https://fake-api-bsyr.onrender.com'
+// src/services/api.js
+// Base de la API obtenida de las variables de entorno de Vite
+// Si no existe la variable se usa la URL de producción por defecto
+const API_BASE = import.meta.env.VITE_API_BASE || 'https://fake-api-bsyr.onrender.com'
+
 export default API_BASE

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,8 +1,9 @@
 // src/domains/shared/services/authService.js
 
-import axios from 'axios';
+import axios from 'axios'
+import API_BASE from './api'
 
-const API_URL = 'http://localhost:3000';
+const API_URL = API_BASE
 
 /**
  * Realiza el login de un cliente a través del email y password.


### PR DESCRIPTION
## Resumen
- leer la URL base de la API desde variables de entorno
- nuevo ejemplo `.env`
- se ignora el archivo `.env`
- se creó `useOrdersStore` con Pinia
- vistas de órdenes actualizadas para usar el store
- se eliminó recarga de página en creación de órdenes
- servicios y vistas actualizados a la nueva API base
- documentación de la variable en README

## Testing
- `git status --short` → sin cambios pendientes


------
https://chatgpt.com/codex/tasks/task_e_683fcb3316c083289a63148877b52147