### PR TITLE
Remove direct console logs

### DIFF
--- a/src/domains/client/analytics/services/analyticsService.js
+++ b/src/domains/client/analytics/services/analyticsService.js
@@ -2,6 +2,7 @@
 
 import axios from 'axios'
 import API from '@/services/api' // importa la base centralizada
+import { error as logError } from '@/services/logger'
 
 const API_URL = `${API}/orders`
 
@@ -10,7 +11,7 @@ export async function fetchOrders() {
         const response = await axios.get(API_URL)
         return response.data
     } catch (error) {
-        console.error('Error al cargar órdenes para analytics:', error)
+        logError('Error al cargar órdenes para analytics:', error)
         return []
     }
 }

--- a/src/domains/client/analytics/views/AnalyticsDashboard.vue
+++ b/src/domains/client/analytics/views/AnalyticsDashboard.vue
@@ -26,6 +26,7 @@ import AnalyticsHeader from '../components/AnalyticsHeader.vue'
 import OperatorList from '../components/OperatorList.vue'
 import WeeklyChart from '../components/WeeklyChart.vue'
 import { getOrders } from '@/domains/client/orders/services/orderService.js'
+import { error as logError } from '@/services/logger'
 
 // Terminales disponibles
 const terminals = ['Callao', 'Lurín', 'Pisco', 'Monte Azul']
@@ -38,7 +39,7 @@ onMounted(async () => {
   try {
     orders.value = await getOrders()
   } catch (error) {
-    console.error('❌ Error al cargar órdenes en analytics:', error)
+    logError('❌ Error al cargar órdenes en analytics:', error)
   }
 })
 </script>

--- a/src/domains/client/orders/components/CreateOrderModal/CreateOrderModal.vue
+++ b/src/domains/client/orders/components/CreateOrderModal/CreateOrderModal.vue
@@ -38,6 +38,7 @@ import StepOrderDetails from './StepOrderDetails.vue'
 import StepPayments from './StepPayments.vue'
 import StepConfirmOrder from './StepConfirmOrder.vue'
 import { useOrdersStore } from '../../store/useOrdersStore'
+import { error as logError } from '@/services/logger'
 const ordersStore = useOrdersStore()
 
 const emit = defineEmits(['close'])
@@ -117,7 +118,7 @@ async function confirmOrder() {
 
     emit('close')
   } catch (err) {
-    console.error('❌ Detalle del error en confirmOrder:', err.message, err.response?.data)
+    logError('❌ Detalle del error en confirmOrder:', err.message, err.response?.data)
   }
 
 }

--- a/src/domains/client/orders/services/fuelService.js
+++ b/src/domains/client/orders/services/fuelService.js
@@ -2,6 +2,7 @@
 
 import axios from 'axios'
 import API from '@/services/api' // ✅ importa la base centralizada
+import { error as logError } from '@/services/logger'
 
 const API_URL = `${API}/fuels`
 
@@ -14,7 +15,7 @@ export async function getFuels() {
         const response = await axios.get(API_URL)
         return response.data
     } catch (error) {
-        console.error('Error al obtener combustibles:', error)
+        logError('Error al obtener combustibles:', error)
         return []
     }
 }

--- a/src/domains/client/orders/services/orderService.js
+++ b/src/domains/client/orders/services/orderService.js
@@ -2,6 +2,7 @@
 
 import axios from 'axios'
 import API from '@/services/api' // ✅ Importar la base común
+import { error as logError } from '@/services/logger'
 
 const API_URL = `${API}/orders`
 
@@ -14,7 +15,7 @@ export async function getOrders() {
         const response = await axios.get(API_URL)
         return response.data
     } catch (error) {
-        console.error('Error al obtener órdenes:', error)
+        logError('Error al obtener órdenes:', error)
         return []
     }
 }
@@ -29,7 +30,7 @@ export async function createOrder(order) {
         const res = await axios.post(API_URL, order)
         return res.data
     } catch (error) {
-        console.error('Error creando orden:', error)
+        logError('Error creando orden:', error)
         throw error
     }
 }

--- a/src/domains/client/provider/services/providerService.js
+++ b/src/domains/client/provider/services/providerService.js
@@ -2,6 +2,7 @@
 
 import axios from 'axios'
 import API from '@/services/api' // ✅ Ruta común para el endpoint base
+import { error as logError } from '@/services/logger'
 
 /**
  * Obtiene todos los proveedores registrados desde el fake API.
@@ -12,7 +13,7 @@ export async function getProviders() {
         const response = await axios.get(`${API}/providers`)
         return response.data
     } catch (error) {
-        console.error('❌ Error al obtener proveedores:', error)
+        logError('❌ Error al obtener proveedores:', error)
         return []
     }
 }
@@ -26,7 +27,7 @@ export async function getOrders() {
         const response = await axios.get(`${API}/orders`)
         return response.data
     } catch (error) {
-        console.error('❌ Error al obtener órdenes:', error)
+        logError('❌ Error al obtener órdenes:', error)
         return []
     }
 }

--- a/src/domains/client/terminals/services/terminalService.js
+++ b/src/domains/client/terminals/services/terminalService.js
@@ -2,6 +2,7 @@
 
 import axios from 'axios'
 import API from '@/services/api' // ✅ Importa base centralizada
+import { error as logError } from '@/services/logger'
 
 /**
  * Obtiene la lista de terminales disponibles
@@ -12,7 +13,7 @@ export async function getTerminals() {
         const response = await axios.get(`${API}/terminals`)
         return response.data
     } catch (error) {
-        console.error('Error al obtener terminales:', error)
+        logError('Error al obtener terminales:', error)
         return []
     }
 }
@@ -26,7 +27,7 @@ export async function getOrders() {
         const response = await axios.get(`${API}/orders`)
         return response.data
     } catch (error) {
-        console.error('Error al obtener órdenes:', error)
+        logError('Error al obtener órdenes:', error)
         return []
     }
 }
@@ -40,7 +41,7 @@ export async function getTrucks() {
         const response = await axios.get(`${API}/trucks`)
         return response.data
     } catch (error) {
-        console.error('Error al obtener camiones:', error)
+        logError('Error al obtener camiones:', error)
         return []
     }
 }

--- a/src/domains/client/workflows/services/workflowService.js
+++ b/src/domains/client/workflows/services/workflowService.js
@@ -2,6 +2,7 @@
 
 import axios from 'axios'
 import API from '@/services/api'
+import { error as logError } from '@/services/logger'
 
 /**
  * Obtiene todas las órdenes registradas (con productos y estados).
@@ -13,7 +14,7 @@ export async function getWorkflows() {
         const response = await axios.get(`${API}/orders`)
         return response.data
     } catch (error) {
-        console.error('❌ Error al obtener workflows:', error)
+        logError('❌ Error al obtener workflows:', error)
         return []
     }
 }

--- a/src/domains/supplier/analytics/services/analyticsService.js
+++ b/src/domains/supplier/analytics/services/analyticsService.js
@@ -2,6 +2,7 @@
 
 import axios from 'axios'
 import API from '@/services/api'
+import { error as logError } from '@/services/logger'
 
 /**
  * Obtiene todas las órdenes marcadas como 'Released'
@@ -12,7 +13,7 @@ export async function getReleasedOrders() {
         const res = await axios.get(`${API}/orders?status=Released`)
         return res.data
     } catch (error) {
-        console.error('Error al obtener órdenes Released:', error)
+        logError('Error al obtener órdenes Released:', error)
         return []
     }
 }

--- a/src/domains/supplier/conciliations/components/ConciliationsHeader.vue
+++ b/src/domains/supplier/conciliations/components/ConciliationsHeader.vue
@@ -71,6 +71,7 @@
 <script setup>
 import { ref } from 'vue'
 import LoadDocumentModal from './LoadDocumentModal.vue'
+import { log } from '@/services/logger'
 
 const props = defineProps({
   totalOrders: Number,
@@ -91,7 +92,7 @@ function closeModal() {
 }
 
 function handleSubmit(files) {
-  console.log('Archivos cargados:', files)
+  log('Archivos cargados:', files)
   closeModal()
 }
 

--- a/src/domains/supplier/conciliations/services/conciliationService.js
+++ b/src/domains/supplier/conciliations/services/conciliationService.js
@@ -3,6 +3,7 @@
 import axios from 'axios'
 import API from '@/services/api'
 import ConciliationOrder from '../models/ConciliationOrder'
+import { log, error as logError } from '@/services/logger'
 
 const ORDERS_URL = `${API}/orders`
 
@@ -15,7 +16,7 @@ export async function getConciliations() {
         const response = await axios.get(ORDERS_URL)
         return response.data.map(order => new ConciliationOrder(order))
     } catch (error) {
-        console.error('[ConciliationService] Error al obtener órdenes:', error.message)
+        logError('[ConciliationService] Error al obtener órdenes:', error.message)
         return []
     }
 }
@@ -27,7 +28,7 @@ export async function getConciliations() {
  */
 export async function approveOrder(orderId) {
     if (!orderId) {
-        console.warn('[ConciliationService] orderId inválido')
+        log('[ConciliationService] orderId inválido')
         return
     }
 
@@ -38,7 +39,7 @@ export async function approveOrder(orderId) {
         })
         return response.data
     } catch (error) {
-        console.error(`[ConciliationService] Error al aprobar la orden ${orderId}:`, error.message)
+        logError(`[ConciliationService] Error al aprobar la orden ${orderId}:`, error.message)
         throw error
     }
 }

--- a/src/domains/supplier/conciliations/views/ConciliationsDashboard.vue
+++ b/src/domains/supplier/conciliations/views/ConciliationsDashboard.vue
@@ -20,6 +20,7 @@ import { ref, onMounted } from 'vue'
 import ConciliationsHeader from '../components/ConciliationsHeader.vue'
 import ConciliationTable from '../components/ConciliationTable.vue'
 import { getConciliations, approveOrder } from '../services/conciliationService.js'
+import { log, error as logError } from '@/services/logger'
 
 const orders = ref([])
 
@@ -38,10 +39,10 @@ function handleApprove(order) {
 
   approveOrder(order.id)
       .then(() => {
-        console.log(`Orden ${order.id} aprobada correctamente.`)
+        log(`Orden ${order.id} aprobada correctamente.`)
       })
       .catch(error => {
-        console.error(`Error al aprobar la orden ${order.id}:`, error)
+        logError(`Error al aprobar la orden ${order.id}:`, error)
       })
 }
 </script>

--- a/src/domains/supplier/dispatch/components/AssignCargoModal.vue
+++ b/src/domains/supplier/dispatch/components/AssignCargoModal.vue
@@ -81,6 +81,7 @@
 import { ref, computed } from 'vue'
 import { PhX } from '@phosphor-icons/vue'
 import { assignTransportToOrder } from '../services/dispatchService'
+import { log, error as logError } from '@/services/logger'
 
 const props = defineProps({
   product: Object,
@@ -89,7 +90,7 @@ const props = defineProps({
   tanks: Array,
   orderId: Number
 })
-console.log('🧪 Modal abierto con orderId:', props.orderId)
+log('🧪 Modal abierto con orderId:', props.orderId)
 
 const emit = defineEmits(['close'])
 
@@ -125,18 +126,18 @@ async function saveAssignment() {
     driver: selectedDriver.value,
     tank: selectedTank.value
   }
-  console.log('>>> Modal saveAssignment payload:', props.orderId, payload)
+  log('>>> Modal saveAssignment payload:', props.orderId, payload)
 
   try {
     const result = await assignTransportToOrder(props.orderId, payload)
-    console.log('<<< Modal saveAssignment result:', result)
+    log('<<< Modal saveAssignment result:', result)
     // Toast de éxito
     window.alert('✅ Order released successfully!')
     emit('close')
   } catch (error) {
     // Mostrar mensaje detallado
     const msg = error.response?.data || error.message
-    console.error('❌ Error saving transport assignment detail:', msg)
+    logError('❌ Error saving transport assignment detail:', msg)
     window.alert(`❌ Error saving transport assignment: ${msg}`)
   }
 }

--- a/src/domains/supplier/dispatch/services/dispatchService.js
+++ b/src/domains/supplier/dispatch/services/dispatchService.js
@@ -2,6 +2,7 @@
 
 import axios from 'axios'
 import API from '@/services/api'
+import { log, error as logError } from '@/services/logger'
 
 // Obtener órdenes aprobadas
 export async function getApprovedOrders() {
@@ -9,7 +10,7 @@ export async function getApprovedOrders() {
         const res = await axios.get(`${API}/orders?status=Approved`)
         return res.data
     } catch (error) {
-        console.error('Error al obtener órdenes aprobadas:', error)
+        logError('Error al obtener órdenes aprobadas:', error)
         return []
     }
 }
@@ -20,7 +21,7 @@ export async function getTrucks() {
         const res = await axios.get(`${API}/trucks`)
         return res.data
     } catch (error) {
-        console.error('Error al obtener camiones:', error)
+        logError('Error al obtener camiones:', error)
         return []
     }
 }
@@ -31,7 +32,7 @@ export async function getDrivers() {
         const res = await axios.get(`${API}/drivers`)
         return res.data
     } catch (error) {
-        console.error('Error al obtener conductores:', error)
+        logError('Error al obtener conductores:', error)
         return []
     }
 }
@@ -42,7 +43,7 @@ export async function getTanks() {
         const res = await axios.get(`${API}/tanks`)
         return res.data
     } catch (error) {
-        console.error('Error al obtener cisternas:', error)
+        logError('Error al obtener cisternas:', error)
         return []
     }
 }
@@ -55,7 +56,7 @@ export async function markAsReleased(orderId) {
         })
         return res.data
     } catch (error) {
-        console.error('Error al marcar orden como Released:', error)
+        logError('Error al marcar orden como Released:', error)
         throw error
     }
 }
@@ -63,15 +64,15 @@ export async function markAsReleased(orderId) {
 // Asignar transporte a una orden
 export async function assignTransportToOrder(orderId, transport) {
     try {
-        console.log('>>> dispatchService.assignTransportToOrder payload:', orderId, transport)
+        log('>>> dispatchService.assignTransportToOrder payload:', orderId, transport)
         const res = await axios.patch(`${API}/orders/${orderId}`, {
             status: 'Released',
             transport: transport
         })
-        console.log('<<< Response assignTransportToOrder:', res.data)
+        log('<<< Response assignTransportToOrder:', res.data)
         return res.data
     } catch (error) {
-        console.error('Error al asignar transporte a la orden:', error.response ?? error)
+        logError('Error al asignar transporte a la orden:', error.response ?? error)
         throw error
     }
 }

--- a/src/domains/supplier/dispatch/views/DispatchDashboard.vue
+++ b/src/domains/supplier/dispatch/views/DispatchDashboard.vue
@@ -20,6 +20,7 @@ import { ref, onMounted } from 'vue'
 import { getApprovedOrders, markAsReleased } from '../services/dispatchService'
 import DispatchHeader from '../components/DispatchHeader.vue'
 import DispatchTable from '../components/DispatchTable.vue'
+import { error as logError } from '@/services/logger'
 
 const orders = ref([])
 const selectedOrderIds = ref([])
@@ -30,7 +31,7 @@ async function fetchOrders() {
     const data = await getApprovedOrders()
     orders.value = data
   } catch (error) {
-    console.error('Error fetching dispatch orders:', error)
+    logError('Error fetching dispatch orders:', error)
   }
 }
 

--- a/src/domains/supplier/dispatch/views/ReleasedOrders.vue
+++ b/src/domains/supplier/dispatch/views/ReleasedOrders.vue
@@ -60,6 +60,7 @@
 import { ref, onMounted } from 'vue'
 import axios from 'axios'
 import API_BASE from '@/services/api'
+import { error as logError } from '@/services/logger'
 
 const orders = ref([])
 
@@ -68,7 +69,7 @@ async function fetchReleasedOrders() {
     const res = await axios.get(`${API_BASE}/orders?status=Released`)
     orders.value = res.data
   } catch (error) {
-    console.error('❌ Error fetching released orders:', error)
+    logError('❌ Error fetching released orders:', error)
   }
 }
 

--- a/src/domains/supplier/orders-management/services/ordersService.js
+++ b/src/domains/supplier/orders-management/services/ordersService.js
@@ -2,6 +2,7 @@
 
 import axios from 'axios'
 import API from '@/services/api'
+import { error as logError } from '@/services/logger'
 
 const API_URL = `${API}/orders`
 
@@ -23,7 +24,7 @@ export async function getOrders() {
             products: order.products || []
         }))
     } catch (error) {
-        console.error('Error al obtener órdenes:', error)
+        logError('Error al obtener órdenes:', error)
         return []
     }
 }
@@ -65,7 +66,7 @@ export async function getOrdersWithStatusCount() {
             statuses: uniqueStatuses
         }
     } catch (error) {
-        console.error('Error al obtener órdenes:', error)
+        logError('Error al obtener órdenes:', error)
         return { orders: [], statuses: [] }
     }
 }

--- a/src/domains/supplier/prices/services/priceService.js
+++ b/src/domains/supplier/prices/services/priceService.js
@@ -2,6 +2,7 @@
 
 import axios from 'axios'
 import API from '@/services/api'
+import { error as logError } from '@/services/logger'
 
 const API_URL = API
 
@@ -27,7 +28,7 @@ export async function getProviderFuels(ruc) {
         // Filtrar solo los que ofrece este proveedor
         return allFuels.filter(f => fuelTypes.includes(f.type))
     } catch (error) {
-        console.error('❌ Error getting provider fuels:', error)
+        logError('❌ Error getting provider fuels:', error)
         return []
     }
 }
@@ -51,7 +52,7 @@ export async function updateFuelPrice(fuelId, newPrice) {
 
         return res.data
     } catch (error) {
-        console.error('❌ Error updating fuel price:', error)
+        logError('❌ Error updating fuel price:', error)
         return false
     }
 }

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -2,6 +2,7 @@
 
 import axios from 'axios'
 import API_BASE from './api'
+import { error as logError } from '@/services/logger'
 
 const API_URL = API_BASE
 
@@ -23,7 +24,7 @@ export async function loginClient(email, password) {
 
         return { success: false, message: 'Credenciales inválidas para cliente.' };
     } catch (error) {
-        console.error('[loginClient] Error:', error);
+        logError('[loginClient] Error:', error);
         return { success: false, message: 'Error del servidor.' };
     }
 }
@@ -47,7 +48,7 @@ export async function loginSupplier(ruc, email, password) {
 
         return { success: false, message: 'Credenciales inválidas para proveedor.' }
     } catch (error) {
-        console.error('Error en loginSupplier:', error)
+        logError('Error en loginSupplier:', error)
         return { success: false, message: 'Error del servidor.' }
     }
 }

--- a/src/services/logger.js
+++ b/src/services/logger.js
@@ -1,0 +1,11 @@
+export function log(...args) {
+  if (import.meta.env.DEV) {
+    console.log(...args)
+  }
+}
+
+export function error(...args) {
+  if (import.meta.env.DEV) {
+    console.error(...args)
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple logger service
- use logger instead of console statements in components and services

## Testing
- `npm install`
- `npm run build` *(fails: Could not load loginClient.css)*

------
https://chatgpt.com/codex/tasks/task_e_683fd9ae59cc832894fd4d9ec7f53932