### PR TITLE
Implementación de i18n en vistas principales

### DIFF
--- a/src/components/shared/SidebarClient.vue
+++ b/src/components/shared/SidebarClient.vue
@@ -7,12 +7,12 @@
     </div>
 
     <ul class="sidebar-menu">
-      <li><router-link to="/client/admin" class="sidebar-link" active-class="active"><i class="fas fa-user"></i> Admin</router-link></li>
-      <li><router-link to="/client/orders" class="sidebar-link" active-class="active"><i class="fas fa-file-alt"></i> Orders</router-link></li>
-      <li><router-link to="/client/analytics" class="sidebar-link" active-class="active"><i class="fas fa-chart-pie"></i> Analytics</router-link></li>
-      <li><router-link to="/client/terminals" class="sidebar-link" active-class="active"><i class="fas fa-gas-pump"></i> Terminals</router-link></li>
-      <li><router-link to="/client/provider" class="sidebar-link" active-class="active"><i class="fas fa-briefcase"></i> Provider</router-link></li>
-      <li><router-link to="/client/workflows" class="sidebar-link" active-class="active"><i class="fas fa-random"></i> Workflows</router-link></li>
+      <li><router-link to="/client/admin" class="sidebar-link" active-class="active"><i class="fas fa-user"></i> {{ $t('sidebar.client.admin') }}</router-link></li>
+      <li><router-link to="/client/orders" class="sidebar-link" active-class="active"><i class="fas fa-file-alt"></i> {{ $t('sidebar.client.orders') }}</router-link></li>
+      <li><router-link to="/client/analytics" class="sidebar-link" active-class="active"><i class="fas fa-chart-pie"></i> {{ $t('sidebar.client.analytics') }}</router-link></li>
+      <li><router-link to="/client/terminals" class="sidebar-link" active-class="active"><i class="fas fa-gas-pump"></i> {{ $t('sidebar.client.terminals') }}</router-link></li>
+      <li><router-link to="/client/provider" class="sidebar-link" active-class="active"><i class="fas fa-briefcase"></i> {{ $t('sidebar.client.provider') }}</router-link></li>
+      <li><router-link to="/client/workflows" class="sidebar-link" active-class="active"><i class="fas fa-random"></i> {{ $t('sidebar.client.workflows') }}</router-link></li>
     </ul>
   </aside>
 </template>

--- a/src/components/shared/SidebarSupplier.vue
+++ b/src/components/shared/SidebarSupplier.vue
@@ -6,13 +6,13 @@
     </div>
 
     <ul class="sidebar-menu">
-      <li><router-link to="/supplier/admin" class="sidebar-link" active-class="active"><i class="ph ph-user"></i> Admin</router-link></li>
-      <li><router-link to="/supplier/orders" class="sidebar-link" active-class="active"><i class="ph ph-clipboard-text"></i> Orders Management</router-link></li>
-      <li><router-link to="/supplier/conciliations" class="sidebar-link" active-class="active"><i class="ph ph-file-check"></i> Conciliations</router-link></li>
-      <li><router-link to="/supplier/dispatch" class="sidebar-link" active-class="active"><i class="ph ph-truck"></i> Dispatch</router-link></li>
-      <li><router-link to="/supplier/analytics" class="sidebar-link" active-class="active"><i class="ph ph-chart-bar"></i> Analytics</router-link></li>
-      <li><router-link to="/supplier/prices" class="sidebar-link" active-class="active"><i class="ph ph-currency-dollar"></i> Prices</router-link></li>
-      <li><router-link to="/supplier/clients" class="sidebar-link" active-class="active"><i class="ph ph-headphones"></i> Clients</router-link></li>
+      <li><router-link to="/supplier/admin" class="sidebar-link" active-class="active"><i class="ph ph-user"></i> {{ $t('sidebar.supplier.admin') }}</router-link></li>
+      <li><router-link to="/supplier/orders" class="sidebar-link" active-class="active"><i class="ph ph-clipboard-text"></i> {{ $t('sidebar.supplier.orders') }}</router-link></li>
+      <li><router-link to="/supplier/conciliations" class="sidebar-link" active-class="active"><i class="ph ph-file-check"></i> {{ $t('sidebar.supplier.conciliations') }}</router-link></li>
+      <li><router-link to="/supplier/dispatch" class="sidebar-link" active-class="active"><i class="ph ph-truck"></i> {{ $t('sidebar.supplier.dispatch') }}</router-link></li>
+      <li><router-link to="/supplier/analytics" class="sidebar-link" active-class="active"><i class="ph ph-chart-bar"></i> {{ $t('sidebar.supplier.analytics') }}</router-link></li>
+      <li><router-link to="/supplier/prices" class="sidebar-link" active-class="active"><i class="ph ph-currency-dollar"></i> {{ $t('sidebar.supplier.prices') }}</router-link></li>
+      <li><router-link to="/supplier/clients" class="sidebar-link" active-class="active"><i class="ph ph-headphones"></i> {{ $t('sidebar.supplier.clients') }}</router-link></li>
     </ul>
   </aside>
 </template>

--- a/src/domains/client/orders/components/FiltersPanel.vue
+++ b/src/domains/client/orders/components/FiltersPanel.vue
@@ -4,21 +4,21 @@
     <div class="totals">
       <div class="item">
         <strong>{{ totalOrders }}</strong>
-        <span>Total Orders</span>
+        <span>{{ $t('orders.filters.total') }}</span>
       </div>
 
       <div class="divider" />
 
       <div class="item status-badge approved">
         {{ approved }}
-        <span>Approved</span>
+        <span>{{ $t('orders.filters.approved') }}</span>
       </div>
 
       <div class="divider" />
 
       <div class="item status-badge requested">
         {{ requested }}
-        <span>Requested</span>
+        <span>{{ $t('orders.filters.requested') }}</span>
       </div>
 
 
@@ -28,27 +28,27 @@
     <div class="actions">
       <div class="relative">
         <button class="filter-button" @click="toggleDropdown">
-          <i class="ph ph-funnel-simple"></i> Filtros
+          <i class="ph ph-funnel-simple"></i> {{ $t('orders.filters.filters') }}
         </button>
 
         <div v-if="showDropdown" class="dropdown">
-          <label>Estado:</label>
+          <label>{{ $t('orders.filters.state') }}:</label>
           <select v-model="status">
-            <option value="">Todos</option>
-            <option value="Requested">Requested</option>
-            <option value="Approved">Approved</option>
-            <option value="Released">Released</option>
-            <option value="Closed">Closed</option>
+            <option value="">{{ $t('orders.filters.all') }}</option>
+            <option value="Requested">{{ $t('orders.filters.requested') }}</option>
+            <option value="Approved">{{ $t('orders.filters.approved') }}</option>
+            <option value="Released">{{ $t('orders.filters.released') }}</option>
+            <option value="Closed">{{ $t('orders.filters.closed') }}</option>
           </select>
 
-          <label>Desde:</label>
+          <label>{{ $t('orders.filters.from') }}:</label>
           <input type="date" v-model="startDate" />
 
-          <label>Hasta:</label>
+          <label>{{ $t('orders.filters.to') }}:</label>
           <input type="date" v-model="endDate" />
 
           <button class="apply-btn" @click="applyFilters">
-            <i class="ph ph-check-circle"></i> Aplicar
+            <i class="ph ph-check-circle"></i> {{ $t('orders.filters.apply') }}
           </button>
         </div>
       </div>
@@ -60,11 +60,11 @@
           <i class="ph ph-x" @click="clearFilter('status')"></i>
         </span>
         <span v-if="startDate" class="chip">
-          <i class="ph ph-calendar-blank"></i> Desde {{ startDate }}
+          <i class="ph ph-calendar-blank"></i> {{ $t('orders.filters.from') }} {{ startDate }}
           <i class="ph ph-x" @click="clearFilter('start')"></i>
         </span>
         <span v-if="endDate" class="chip">
-          <i class="ph ph-calendar-blank"></i> Hasta {{ endDate }}
+          <i class="ph ph-calendar-blank"></i> {{ $t('orders.filters.to') }} {{ endDate }}
           <i class="ph ph-x" @click="clearFilter('end')"></i>
         </span>
       </div>

--- a/src/domains/client/orders/components/OrderRow.vue
+++ b/src/domains/client/orders/components/OrderRow.vue
@@ -12,7 +12,7 @@
     <td>{{ order.terminal }}</td>
     <td class="order-id">
       <span>{{ order.orderId }}</span>
-      <i class="ph ph-copy" @click.stop="copyToClipboard(order.orderId)" title="Copiar ID"></i>
+      <i class="ph ph-copy" @click.stop="copyToClipboard(order.orderId)" :title="$t('orders.table.copy_id')"></i>
     </td>
     <td>
         <span :class="['status', order.status.toLowerCase()]">

--- a/src/domains/client/orders/components/OrdersTable.vue
+++ b/src/domains/client/orders/components/OrdersTable.vue
@@ -2,12 +2,12 @@
   <table class="orders-table">
     <thead>
     <tr>
-      <th>Creado</th>
-      <th>Usuario</th>
-      <th>Monto</th>
-      <th>Terminal</th>
-      <th>ID de Orden</th>
-      <th>Estado</th>
+      <th>{{ $t('orders.table.created') }}</th>
+      <th>{{ $t('orders.table.user') }}</th>
+      <th>{{ $t('orders.table.amount') }}</th>
+      <th>{{ $t('orders.table.terminal') }}</th>
+      <th>{{ $t('orders.table.order_id') }}</th>
+      <th>{{ $t('orders.table.status') }}</th>
     </tr>
     </thead>
 

--- a/src/domains/client/orders/views/OrdersList.vue
+++ b/src/domains/client/orders/views/OrdersList.vue
@@ -1,13 +1,13 @@
 <template>
   <section class="orders-list">
-    <h1>My orders </h1>
+    <h1>{{ $t('orders.my_orders') }} </h1>
 
     <!-- Filtros -->
     <FiltersPanel @filter="applyFilters" />
 
     <!-- Botón crear orden -->
     <button @click="showModal = true" class="create-btn">
-      <i class="ph ph-plus-circle"></i> Crear orden
+      <i class="ph ph-plus-circle"></i> {{ $t('orders.create_order') }}
     </button>
 
     <!-- Tabla de órdenes -->

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,1 +1,75 @@
-{}
+{
+  "welcome": {
+    "title": "Welcome to FuelTrack",
+    "subtitle": "Select your user type to continue:",
+    "client_title": "Client",
+    "client_desc": "Companies requesting fuel",
+    "supplier_title": "Supplier",
+    "supplier_desc": "Companies supplying fuel"
+  },
+  "login": {
+    "client": {
+      "subtitle": "Optimize your fuel orders management",
+      "submit": "Enter as Client",
+      "not_client": "Not a Client?"
+    },
+    "supplier": {
+      "subtitle": "Supplier Access Portal",
+      "submit": "Enter as Supplier",
+      "not_supplier": "Not a Supplier?"
+    },
+    "demo_client": "✅ Logged in as demo client",
+    "demo_supplier": "✅ Logged in as demo supplier"
+  },
+  "sidebar": {
+    "client": {
+      "admin": "Admin",
+      "orders": "Orders",
+      "analytics": "Analytics",
+      "terminals": "Terminals",
+      "provider": "Provider",
+      "workflows": "Workflows"
+    },
+    "supplier": {
+      "admin": "Admin",
+      "orders": "Orders Management",
+      "conciliations": "Conciliations",
+      "dispatch": "Dispatch",
+      "analytics": "Analytics",
+      "prices": "Prices",
+      "clients": "Clients"
+    }
+  },
+  "orders": {
+    "my_orders": "My orders",
+    "create_order": "Create order",
+    "filters": {
+      "total": "Total Orders",
+      "approved": "Approved",
+      "requested": "Requested",
+      "filters": "Filters",
+      "state": "Status",
+      "all": "All",
+      "released": "Released",
+      "closed": "Closed",
+      "from": "From",
+      "to": "To",
+      "apply": "Apply"
+    },
+    "table": {
+      "created": "Created",
+      "user": "User",
+      "amount": "Amount",
+      "terminal": "Terminal",
+      "order_id": "Order ID",
+      "status": "Status",
+      "copy_id": "Copy ID"
+    }
+  },
+  "common": {
+    "email": "Email Address",
+    "password": "Password",
+    "ruc": "RUC",
+    "click_here": "Click Here"
+  }
+}

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,1 +1,75 @@
-{}
+{
+  "welcome": {
+    "title": "Bienvenido a FuelTrack",
+    "subtitle": "Selecciona tu tipo de usuario para continuar:",
+    "client_title": "Cliente",
+    "client_desc": "Empresas que solicitan combustible",
+    "supplier_title": "Proveedor",
+    "supplier_desc": "Empresas que abastecen combustible"
+  },
+  "login": {
+    "client": {
+      "subtitle": "Optimiza la gestión de tus pedidos de combustible",
+      "submit": "Ingresar como Cliente",
+      "not_client": "¿No eres Cliente?"
+    },
+    "supplier": {
+      "subtitle": "Portal de acceso para Proveedores",
+      "submit": "Ingresar como Proveedor",
+      "not_supplier": "¿No eres Proveedor?"
+    },
+    "demo_client": "✅ Acceso de demostración como cliente",
+    "demo_supplier": "✅ Acceso de demostración como proveedor"
+  },
+  "sidebar": {
+    "client": {
+      "admin": "Admin",
+      "orders": "Órdenes",
+      "analytics": "Analítica",
+      "terminals": "Terminales",
+      "provider": "Proveedor",
+      "workflows": "Flujos"
+    },
+    "supplier": {
+      "admin": "Admin",
+      "orders": "Gestión de Órdenes",
+      "conciliations": "Conciliaciones",
+      "dispatch": "Despacho",
+      "analytics": "Analítica",
+      "prices": "Precios",
+      "clients": "Clientes"
+    }
+  },
+  "orders": {
+    "my_orders": "Mis órdenes",
+    "create_order": "Crear orden",
+    "filters": {
+      "total": "Órdenes Totales",
+      "approved": "Aprobadas",
+      "requested": "Solicitadas",
+      "filters": "Filtros",
+      "state": "Estado",
+      "all": "Todos",
+      "released": "Liberadas",
+      "closed": "Cerradas",
+      "from": "Desde",
+      "to": "Hasta",
+      "apply": "Aplicar"
+    },
+    "table": {
+      "created": "Creado",
+      "user": "Usuario",
+      "amount": "Monto",
+      "terminal": "Terminal",
+      "order_id": "ID de Orden",
+      "status": "Estado",
+      "copy_id": "Copiar ID"
+    }
+  },
+  "common": {
+    "email": "Correo electrónico",
+    "password": "Contraseña",
+    "ruc": "RUC",
+    "click_here": "Haz clic aquí"
+  }
+}

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -1,19 +1,19 @@
 <!-- src/pages/WelcomePage.vue -->
 <template>
   <div class="welcome-container">
-    <h1 class="title">Bienvenido a FuelTrack</h1>
-    <p class="subtitle">Selecciona tu tipo de usuario para continuar:</p>
+    <h1 class="title">{{ $t('welcome.title') }}</h1>
+    <p class="subtitle">{{ $t('welcome.subtitle') }}</p>
 
     <div class="card-group">
       <div class="card" @click="goTo('/login-client')">
         <i class="ph ph-user"></i>
-        <h2>Cliente</h2>
-        <p>Empresas que solicitan combustible</p>
+        <h2>{{ $t('welcome.client_title') }}</h2>
+        <p>{{ $t('welcome.client_desc') }}</p>
       </div>
       <div class="card" @click="goTo('/login-supplier')">
         <i class="ph ph-briefcase"></i>
-        <h2>Proveedor</h2>
-        <p>Empresas que abastecen combustible</p>
+        <h2>{{ $t('welcome.supplier_title') }}</h2>
+        <p>{{ $t('welcome.supplier_desc') }}</p>
       </div>
     </div>
   </div>

--- a/src/pages/client/LoginClient.vue
+++ b/src/pages/client/LoginClient.vue
@@ -3,7 +3,7 @@
     <div class="login-card">
       <img src="/img/logo.png" alt="FuelTrack Logo" class="logo" />
       <h1 class="title">FuelTrack</h1>
-      <p class="subtitle">Optimize your fuel orders management</p>
+      <p class="subtitle">{{ $t('login.client.subtitle') }}</p>
 
       <!-- Simulación de formulario -->
       <form @submit.prevent="fakeLogin">
@@ -11,22 +11,22 @@
             id="email"
             type="email"
             v-model="email"
-            placeholder="Email Address"
+            :placeholder="$t('common.email')"
             required
         />
         <input
             id="password"
             type="password"
             v-model="password"
-            placeholder="Password"
+            :placeholder="$t('common.password')"
             required
         />
-        <button type="submit" class="login-button">Enter as Client</button>
+        <button type="submit" class="login-button">{{ $t('login.client.submit') }}</button>
       </form>
 
       <p class="register-text">
-        Not a Client?
-        <a href="#" class="register-link">Click Here</a>
+        {{ $t('login.client.not_client') }}
+        <a href="#" class="register-link">{{ $t('common.click_here') }}</a>
       </p>
     </div>
   </div>
@@ -43,7 +43,7 @@ export default {
   },
   methods: {
     fakeLogin() {
-      alert('✅ Logged in as demo client')
+      alert(this.$t('login.demo_client'))
       this.$router.push('/client/orders')
     }
   }

--- a/src/pages/supplier/LoginSupplier.vue
+++ b/src/pages/supplier/LoginSupplier.vue
@@ -3,13 +3,13 @@
     <div class="login-card">
       <img src="/img/logo.png" alt="FuelTrack Logo" class="logo" />
       <h1 class="title">FuelTrack</h1>
-      <p class="subtitle">Supplier Access Portal</p>
+      <p class="subtitle">{{ $t('login.supplier.subtitle') }}</p>
 
       <form @submit.prevent="fakeLogin">
         <input
             type="text"
             v-model="ruc"
-            placeholder="RUC"
+            :placeholder="$t('common.ruc')"
             required
             aria-label="RUC"
         />
@@ -17,7 +17,7 @@
         <input
             type="email"
             v-model="email"
-            placeholder="Email Address"
+            :placeholder="$t('common.email')"
             required
             aria-label="Email Address"
         />
@@ -25,16 +25,16 @@
         <input
             type="password"
             v-model="password"
-            placeholder="Password"
+            :placeholder="$t('common.password')"
             required
             aria-label="Password"
         />
 
-        <button type="submit" class="login-button">Enter as Supplier</button>
+        <button type="submit" class="login-button">{{ $t('login.supplier.submit') }}</button>
       </form>
 
       <p class="register-text">
-        Not a Supplier? <router-link to="/register-supplier" class="register-link">Click here</router-link>
+        {{ $t('login.supplier.not_supplier') }} <router-link to="/register-supplier" class="register-link">{{ $t('common.click_here') }}</router-link>
       </p>
     </div>
   </div>
@@ -52,7 +52,7 @@ export default {
   },
   methods: {
     fakeLogin() {
-      alert('✅ Logged in as demo supplier')
+      alert(this.$t('login.demo_supplier'))
       this.$router.push('/supplier') // Asegúrate que esta ruta exista
     }
   }


### PR DESCRIPTION
## Resumen
- añadir cadenas de texto en `en.json` y `es.json`
- aplicar `$t` en las vistas de bienvenida y login
- internacionalizar las barras laterales y la lista de órdenes

## Testing
- `npm test` *(falla: Missing script)*
- `npm run lint` *(falla: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fd9afe3fc8328aefffec7e89882e0