### PR TITLE
Add language toggle button

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,13 @@
 <template>
+  <LanguageToggle />
   <router-view />
 </template>
 
 <script>
+import LanguageToggle from '@/components/shared/LanguageToggle.vue'
+
 export default {
-  name: 'App'
+  name: 'App',
+  components: { LanguageToggle }
 }
 </script>

--- a/src/components/shared/LanguageToggle.vue
+++ b/src/components/shared/LanguageToggle.vue
@@ -1,0 +1,32 @@
+<template>
+  <button class="lang-toggle" @click="toggleLanguage">
+    {{ currentLabel }}
+  </button>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { locale } = useI18n()
+
+const currentLabel = computed(() => (locale.value === 'es' ? 'EN' : 'ES'))
+
+function toggleLanguage() {
+  locale.value = locale.value === 'es' ? 'en' : 'es'
+}
+</script>
+
+<style scoped>
+.lang-toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  background-color: #219653;
+  color: white;
+  font-weight: bold;
+  z-index: 1000;
+}
+</style>

--- a/tests/SidebarClient.test.js
+++ b/tests/SidebarClient.test.js
@@ -1,11 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import SidebarClient from '../src/components/shared/SidebarClient.vue'
+import { i18n } from '../src/i18n'
 
 describe('SidebarClient', () => {
   it('renderiza enlaces principales', () => {
     const wrapper = mount(SidebarClient, {
       global: {
+        plugins: [i18n],
         stubs: {
           'router-link': { template: '<a><slot /></a>' }
         }


### PR DESCRIPTION
## Summary
- create `LanguageToggle` component to change `vue-i18n` locale
- display the language toggle globally from `App.vue`
- update `SidebarClient` test to install the i18n plugin

## Testing
- `npm test` *(fails: expected 'FuelTrack Admin Órdenes ...' to contain 'Orders')*

------
https://chatgpt.com/codex/tasks/task_e_683fdd6397ec83289f85a1219ca1fb36