### PR TITLE
Mejora de diseño en modal de órdenes

### DIFF
--- a/src/domains/client/orders/components/CreateOrderModal/CreateOrderModal.vue
+++ b/src/domains/client/orders/components/CreateOrderModal/CreateOrderModal.vue
@@ -145,7 +145,7 @@ function calcularTotal(details) {
   left: 0;
   width: 100vw;
   height: 100vh;
-  background-color: rgba(0, 0, 0, 0.35);
+  background-color: rgba(15, 23, 42, 0.55);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -153,14 +153,14 @@ function calcularTotal(details) {
 }
 
 .modal-content {
-  background-color: white;
+  background-color: #ffffff;
   width: 90%;
   max-width: 860px;
   max-height: 90vh;
   display: flex;
   flex-direction: column;
-  border-radius: 12px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.12);
   overflow: hidden;
 }
 
@@ -171,6 +171,7 @@ function calcularTotal(details) {
   justify-content: space-between;
   align-items: center;
   flex-shrink: 0;
+  background-color: #f9fafb;
 }
 
 .modal-body {
@@ -192,8 +193,12 @@ function calcularTotal(details) {
   background: none;
   border: none;
   font-size: 1.3rem;
-  color: #64748b;
+  color: #475569;
   cursor: pointer;
+  transition: color 0.2s ease;
+}
+.close-btn:hover {
+  color: #1e293b;
 }
 
 .btn {

--- a/src/domains/client/orders/components/CreateOrderModal/StepPayments.vue
+++ b/src/domains/client/orders/components/CreateOrderModal/StepPayments.vue
@@ -42,6 +42,7 @@
           <div class="bank-wrapper">
             <select
                 :value="payment.account"
+                :class="{ invalid: submitted && !payment.account }"
                 @input="e => updatePayment(detailIndex, paymentIndex, 'account', e.target.value)"
             >
               <option value="">Seleccione banco</option>
@@ -56,6 +57,7 @@
                 class="bank-logo"
             />
           </div>
+          <span v-if="submitted && !payment.account" class="error">Requerido</span>
           </div>
 
         <div class="field">
@@ -64,9 +66,11 @@
               type="number"
               min="0"
               :value="payment.amount"
+              :class="{ invalid: submitted && (!payment.amount || payment.amount <= 0) }"
               @input="e => updatePayment(detailIndex, paymentIndex, 'amount', Number(e.target.value))"
               placeholder="Ingrese el monto"
           />
+          <span v-if="submitted && (!payment.amount || payment.amount <= 0)" class="error">Requerido</span>
         </div>
 
         <div class="field">
@@ -74,8 +78,10 @@
           <input
               type="datetime-local"
               :value="payment.date"
+              :class="{ invalid: submitted && !payment.date }"
               @input="e => updatePayment(detailIndex, paymentIndex, 'date', e.target.value)"
           />
+          <span v-if="submitted && !payment.date" class="error">Requerido</span>
         </div>
 
         <div class="field with-remove">
@@ -84,6 +90,7 @@
             <input
                 type="text"
                 :value="payment.operationNumber"
+                :class="{ invalid: submitted && !payment.operationNumber }"
                 @input="e => updatePayment(detailIndex, paymentIndex, 'operationNumber', e.target.value)"
                 placeholder="Ingrese número"
             />
@@ -96,6 +103,7 @@
               <i class="ph ph-trash-simple"></i>
             </button>
           </div>
+          <span v-if="submitted && !payment.operationNumber" class="error">Requerido</span>
         </div>
       </div>
       </TransitionGroup>
@@ -120,7 +128,7 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, watch, ref } from 'vue'
 
 const props = defineProps({
   modelValue: {
@@ -129,7 +137,9 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['update:modelValue'])
+const emit = defineEmits(['update:modelValue', 'invalid'])
+
+const submitted = ref(false)
 
 const orderDetails = computed(() => props.modelValue.details || [])
 const payments = computed(() => props.modelValue.payments || [])
@@ -139,6 +149,14 @@ const bankLogos = {
   BBVA: '/img/banks/bbva.png',
   Interbank: '/img/banks/interbank.png'
 }
+
+watch(payments, () => {
+  submitted.value = true
+  const invalid = payments.value.some(group =>
+    group.some(p => !p.account || p.amount <= 0 || !p.date || !p.operationNumber)
+  )
+  if (invalid) emit('invalid')
+}, { deep: true })
 
 function addPayment(detailIndex) {
   const updated = [...payments.value]
@@ -276,6 +294,18 @@ function updatePayment(detailIndex, paymentIndex, field, value) {
   font-size: 0.9rem;
   background-color: #f9fafb;
   transition: border-color 0.2s;
+}
+
+input.invalid,
+select.invalid {
+  border-color: #ef4444;
+  background-color: #fef2f2;
+}
+
+.error {
+  font-size: 0.75rem;
+  color: #dc2626;
+  margin-top: 0.25rem;
 }
 
 .field input:focus,


### PR DESCRIPTION
## Summary
- mejorar estilos del modal de creación de órdenes
- validar campos en pagos y emitir error

## Testing
- `npm test` *(falla)*

------
https://chatgpt.com/codex/tasks/task_e_68407e16f29c832895221cceb77f1234